### PR TITLE
Grain Fermentation Rework

### DIFF
--- a/grainalcoholrework.js
+++ b/grainalcoholrework.js
@@ -1,0 +1,177 @@
+runAfterLoad(function() {
+
+    // =====================================================
+    // YEAST PATCH (remove unwanted fermentations)
+    // =====================================================
+    const yeastBlocked = [
+        "corn",
+        "rice",
+        "wheat",
+        "potato",
+        "mashed_potato"
+    ];
+
+    yeastBlocked.forEach(item => {
+
+        if (elements.yeast?.reactions?.[item]) {
+            delete elements.yeast.reactions[item];
+        }
+
+        if (elements[item]?.reactions?.yeast) {
+            delete elements[item].reactions.yeast;
+        }
+    });
+
+    // =====================================================
+    // FOAM (byproduct of fermentation)
+    // =====================================================
+    elements.foam = {
+        color: "#e6f7ff",
+        behavior: behaviors.LIQUID,
+        category: "food",
+        state: "liquid",
+        density: 50,
+        hidden: true
+    };
+
+    // =====================================================
+    // BARLEY SYSTEM
+    // =====================================================
+    elements.barley = {
+        color: "#a67c52",
+        behavior: behaviors.POWDER,
+        category: "food",
+        state: "solid",
+        density: 750,
+        reactions: {
+            water: {
+                elem1: "green_barley",
+                elem2: null
+            }
+        }
+    };
+
+    elements.green_barley = {
+        color: "#6fa84a",
+        behavior: behaviors.POWDER,
+        category: "food",
+        state: "solid",
+        density: 800,
+        hidden: true,
+
+        tick: function(pixel) {
+
+            if (pixel.temp >= 100) {
+                changePixel(pixel, "dead_plant");
+                return;
+            }
+
+            if (pixel.temp >= 85) {
+                changePixel(pixel, "malted_barley");
+                return;
+            }
+        }
+    };
+
+    elements.malted_barley = {
+        color: "#c2a66b",
+        behavior: behaviors.POWDER,
+        category: "food",
+        state: "solid",
+        density: 780,
+        hidden: true
+    };
+
+    // =====================================================
+    // RYE (FIXED - WAS MISSING)
+    // =====================================================
+    elements.rye = {
+        color: "#8b3a3a",
+        behavior: behaviors.POWDER,
+        category: "food",
+        state: "solid",
+        density: 720
+    };
+
+    // =====================================================
+    // S VARIANTS + SACCHARIFICATION
+    // =====================================================
+    const grains = [
+        "corn",
+        "rice",
+        "wheat",
+        "potato",
+        "mashed_potato",
+        "rye"
+    ];
+
+    grains.forEach(food => {
+
+        const sName = "S_" + food;
+
+        elements[sName] = {
+            color: "#d8c27a",
+            behavior: behaviors.POWDER,
+            category: "food",
+            state: "solid",
+            density: elements[food]?.density || 700,
+            hidden: true
+        };
+
+        // malted barley converts grain → sugar form
+        if (!elements.malted_barley.reactions) {
+            elements.malted_barley.reactions = {};
+        }
+
+        elements.malted_barley.reactions[food] = {
+            elem1: sName,
+            elem2: null
+        };
+    });
+
+    // =====================================================
+    // YEAST FERMENTATION + FOAM SYSTEM
+    // =====================================================
+    const sGrains = [
+        "S_corn",
+        "S_rice",
+        "S_wheat",
+        "S_potato",
+        "S_mashed_potato",
+        "S_rye"
+    ];
+
+    sGrains.forEach(s => {
+
+        if (!elements.yeast.reactions) {
+            elements.yeast.reactions = {};
+        }
+
+        elements.yeast.reactions[s] = {
+            elem1: "alcohol",
+            elem2: null
+        };
+    });
+
+    // alcohol foam production
+    if (elements.alcohol) {
+
+        const oldTick = elements.alcohol.tick;
+
+        elements.alcohol.tick = function(pixel) {
+
+            if (oldTick) oldTick(pixel);
+
+            if (Math.random() < 0.03) {
+                const dir = Math.floor(Math.random() * 4);
+                const x = pixel.x + (dir === 0 ? 1 : dir === 1 ? -1 : 0);
+                const y = pixel.y + (dir === 2 ? 1 : dir === 3 ? -1 : 0);
+
+                if (isEmpty(x, y)) {
+                    createPixel("foam", x, y);
+                }
+            }
+        };
+    }
+
+});


### PR DESCRIPTION
This mod adds more realism to Sandboxels fermentation, adding rye, and barley. Using Barley you can break down the complex sugars within grains and potatoes to make alcohol in a more realistic way, instead of the default grains working. Barley is how you break down the grains, and you must malt it, to malt it, you add water, then heat to 85 degrees, which turns it to green barley, then malted barley, malted barley will react with grains creating their s variations, the S stands for Sugars since the malted barley broke down the complex sugars to make them useable for fermentation, similar to real life.